### PR TITLE
Fix contact serialization

### DIFF
--- a/src/Contact.php
+++ b/src/Contact.php
@@ -112,11 +112,11 @@ final class Contact implements JsonSerializable
             });
         }
 
-        if ($this->emails !== null) {
+        if (count($this->emails) > 0) {
             $contact->emails = $this->emails;
         }
 
-        if ($this->phones !== null) {
+        if (count($this->phones) > 0) {
             $contact->phones = $this->phones;
         }
 

--- a/tests/unit/CompetitionSaveTest.php
+++ b/tests/unit/CompetitionSaveTest.php
@@ -228,4 +228,13 @@ final class CompetitionSaveTest extends TestCase {
         $saved_competition = Competition::loadFromFile(realpath(join(DIRECTORY_SEPARATOR, array(__DIR__, 'competitions', 'save'))), 'competition-metadata-season-2324.json');
         $this->assertEquals('2023-2024', $saved_competition->getMetadataByKey('season'));
     }
+
+    public function testCompetitionSaveCompetitionWithContacts() : void
+    {
+        $competition = Competition::loadFromFile(realpath(join(DIRECTORY_SEPARATOR, array(__DIR__, 'contacts'))), 'contacts.json');
+        $competition->setName('Saved Competition');
+        $competition->saveToFile(realpath(join(DIRECTORY_SEPARATOR, array(__DIR__, 'competitions', 'save'))), 'contacts.json');
+        $saved_competition = Competition::loadFromFile(realpath(join(DIRECTORY_SEPARATOR, array(__DIR__, 'competitions', 'save'))), 'contacts.json');
+        $this->assertEquals('frankie@example.com', $saved_competition->getTeam('TM3')->getContact('C6')->getEmails()[0]);
+    }
 }

--- a/tests/unit/contacts/contacts.json
+++ b/tests/unit/contacts/contacts.json
@@ -67,7 +67,6 @@
           "id": "C7",
           "name": "George Grey",
           "roles": ["medic"],
-          "emails": ["george@example.com"],
           "phones": ["01234 567895"]
         }
       ]


### PR DESCRIPTION
Fix a bug in contact serialization where the emails and phones would resolve to an empty array if nothing was present, which would result in a schema validation error