### PR TITLE
fix: HTML match functions should handle "ifUnknown" blocks too

### DIFF
--- a/docs/api/classes/VBCompetitions-Competitions-HTML.html
+++ b/docs/api/classes/VBCompetitions-Competitions-HTML.html
@@ -2217,7 +2217,7 @@ in a way where the caller can manipulate the data (for example injecting their o
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">private</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">generateBreakRow</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">object&nbsp;</span><span class="phpdocumentor-signature__argument__name">$config</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type"><a href="classes/VBCompetitions-Competitions-GroupBreak.html"><abbr title="\VBCompetitions\Competitions\GroupBreak">GroupBreak</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$break</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">generateBreakRow</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">object&nbsp;</span><span class="phpdocumentor-signature__argument__name">$config</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type"><a href="classes/VBCompetitions-Competitions-BreakInterface.html"><abbr title="\VBCompetitions\Competitions\BreakInterface">BreakInterface</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$break</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -2233,7 +2233,7 @@ in a way where the caller can manipulate the data (for example injecting their o
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$break</span>
-                : <span class="phpdocumentor-signature__argument__return-type"><a href="classes/VBCompetitions-Competitions-GroupBreak.html"><abbr title="\VBCompetitions\Competitions\GroupBreak">GroupBreak</abbr></a></span>
+                : <span class="phpdocumentor-signature__argument__return-type"><a href="classes/VBCompetitions-Competitions-BreakInterface.html"><abbr title="\VBCompetitions\Competitions\BreakInterface">BreakInterface</abbr></a></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The group break object</p>

--- a/src/HTML.php
+++ b/src/HTML.php
@@ -768,10 +768,10 @@ class HTML {
      * Generates a break row.
      *
      * @param object $config The configuration object
-     * @param GroupBreak $break The group break object
+     * @param BreakInterface $break The group break object
      * @return array The generated break row
      */
-    private static function generateBreakRow(object $config, GroupBreak $break) : array
+    private static function generateBreakRow(object $config, BreakInterface $break) : array
     {
         $cells = [];
         $col_span = 1;
@@ -999,10 +999,10 @@ class HTML {
         $table->headings = $match_list_heading->headings;
         $table->rows = [];
         foreach ($match_container->getMatches($team_id, $flags) as $match) {
-            if ($match instanceof GroupBreak) {
+            if ($match instanceof BreakInterface) {
                 // TODO - how do we know width?
                 array_push($table->rows, HTML::generateBreakRow($config, $match));
-            } else if ($match instanceof GroupMatch) {
+            } else if ($match instanceof MatchInterface) {
                 array_push($table->rows, HTML::generateMatchRow($match_container, $config, $match, $team_id));// $home_team_match, $away_team_match, $official_team_match, $manager_team_match));
             }
         }

--- a/tests/unit/HTMLTest.php
+++ b/tests/unit/HTMLTest.php
@@ -883,6 +883,22 @@ final class HTMLTest extends TestCase {
         );
     }
 
+    public function testHTMLMatchesHTMLIfUnknown() : void
+    {
+        $competition = Competition::loadFromFile(realpath(join(DIRECTORY_SEPARATOR, array(__DIR__, 'html'))), 'complete-league.json');
+        $matches_html = HTML::getMatchesHTML($competition->getStage('L')->getIfUnknown());
+
+        $expected_table = '<table class="vbc-match vbc-match-group-unknown">';
+        $expected_table .= '<tr><th class="vbc-match-id vbc-match-group-unknown">MatchNo</th><th class="vbc-match-court vbc-match-group-unknown">Court</th><th class="vbc-match-start vbc-match-group-unknown">Start</th><th class="vbc-match-duration vbc-match-group-unknown">Duration</th><th class="vbc-match-team vbc-match-group-unknown">Home Team</th><th class="vbc-match-score vbc-match-group-unknown" colspan="2">Score</th><th class="vbc-match-team vbc-match-group-unknown">Away Team</th></tr>';
+        $expected_table .= '<tr><td class="vbc-unknown-value vbc-match-id vbc-match-group-unknown">MF</td><td class="vbc-unknown-value vbc-match-court vbc-match-group-unknown">1</td><td class="vbc-unknown-value vbc-match-start vbc-match-group-unknown">16:30</td><td class="vbc-unknown-value vbc-match-duration vbc-match-group-unknown">0:20</td><td class="vbc-unknown-value vbc-match-team vbc-match-group-unknown">UNKNOWN</td><td class="vbc-unknown-value vbc-match-score vbc-match-group-unknown">0</td><td class="vbc-unknown-value vbc-match-score vbc-match-group-unknown">0</td><td class="vbc-unknown-value vbc-match-team vbc-match-group-unknown">UNKNOWN</td></tr>';
+        $expected_table .= '</table>';
+
+        $this->assertEquals(
+            $expected_table,
+            $matches_html
+        );
+    }
+
     public function testHTMLMatchesHTMLNoMatches() : void
     {
         $competition = Competition::loadFromFile(realpath(join(DIRECTORY_SEPARATOR, array(__DIR__, 'html'))), 'empty.json');

--- a/tests/unit/html/complete-league.json
+++ b/tests/unit/html/complete-league.json
@@ -30,7 +30,28 @@
             { "id": "LG6", "court": "1", "type": "match", "start": "15:20", "duration": "0:20", "complete": true, "homeTeam": { "id": "TM1", "scores": [ 26 ] }, "awayTeam": { "id": "TM2", "scores": [ 32 ] }, "officials": { "team": "TM4" } }
           ]
         }
-      ]
+      ],
+      "ifUnknown": {
+        "description": ["The finals will be held between the top two places"],
+        "matches": [
+          {
+            "id": "MF",
+            "court": "1",
+            "type": "match",
+            "start": "16:30",
+            "duration": "0:20",
+            "complete": false,
+            "homeTeam": {
+              "id": "1st",
+              "scores": []
+            },
+            "awayTeam": {
+              "id": "2nd",
+              "scores": []
+            }
+          }
+        ]
+      }
     },
     {
       "name": "League",


### PR DESCRIPTION
Fixes the getMatchTable code so that it uses the `BreakInterface` and `MatchInterface` checks rather than only the `GroupBreak` and `GroupMatch` checks